### PR TITLE
feat(dashboard): auto-populate system prompt interceptor on first load

### DIFF
--- a/packages/dashboard-web/src/api.ts
+++ b/packages/dashboard-web/src/api.ts
@@ -64,6 +64,10 @@ export interface SystemPromptConfig {
 	};
 	/** List of available tools from the last-seen main agent request */
 	availableTools: Tool[];
+	/** The last-seen system prompt captured from requests */
+	lastSeenPrompt?: string;
+	/** Whether the saved target prompt differs from the last-seen prompt */
+	hasPromptChanged?: boolean;
 }
 
 class API extends HttpClient {


### PR DESCRIPTION
## Summary
- Fixes issue where Target Prompt field was blank on first load until "Reset to Default" was clicked
- Target Prompt now automatically populates when a system prompt is captured
- Users are notified when the system prompt changes with option to update

## Changes
- **Backend**: API now always returns `lastSeenPrompt` and `hasPromptChanged` flag
- **Frontend**: Auto-populates Target Prompt field when empty but prompt is available
- **UX**: Added visual indicators and "Update to Latest" button for prompt changes
- **Polling**: 60-second interval detects and notifies of system prompt changes

## Test Plan
- [ ] Start with no interceptor configuration
- [ ] Make a request to Claude to capture system prompt
- [ ] Verify Target Prompt field auto-populates (no need to click Reset)
- [ ] Modify the system prompt externally
- [ ] Verify "System prompt has changed" indicator appears
- [ ] Click "Update to Latest" and verify prompt updates
- [ ] Test placeholder text when no prompt captured yet